### PR TITLE
Update src/mcover/util/Timer.hx

### DIFF
--- a/src/mcover/util/Timer.hx
+++ b/src/mcover/util/Timer.hx
@@ -73,6 +73,7 @@ import cpp.vm.Thread;
 @IgnoreCover
 @IgnoreLogging
 
+@:expose('mcover.util.Timer')
 class Timer 
 {
 	public var run:Void -> Void;


### PR DESCRIPTION
JS:Timer issue when running with -js-modern. Which is going to be the default for haxe3, but at least this should be a good citizen. Similar bug to https://github.com/massiveinteractive/MassiveUnit/issues/40. Possibly Timer should be moved into the massivelib repo and used from there? 
