### PR TITLE
Version 1.5.0 - Improved logic for covering macro generated code blocks

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+v 1.5.0
+- added better coverage handling/ support for macro generated functions/code blocks
+
 v 1.4.2
 - cache file naming causing issues on some platforms
 - minor compatibility updates for building with haxe svn (2.11)

--- a/build/Build.hx
+++ b/build/Build.hx
@@ -11,7 +11,7 @@ class Build extends mtask.core.BuildBase
 	{
 		t.url = "http://github.com/massiveinteractive/mcover";
 		t.description = "A cross platform code coverage framework for Haxe with testing and profiling applications. Supports AVM1, AVM2, JavaScript, C++, PHP and Neko.";
-		t.versionDescription = "Minor tweaks to support haxe svn (2.11). See CHANGES for details.";
+		t.versionDescription = "Added better handling/support for coverage of macro generated functions/code blocks";
 
 		t.addTag("cross");
 		t.addTag("macro");
@@ -24,6 +24,11 @@ class Build extends mtask.core.BuildBase
 		{
 			rm("src/haxelib.xml");
 			cp("src/*", path);
+		}
+
+		t.afterCompile = function(path)
+		{
+			cp("bin/release/haxelib/haxelib.xml", "src/haxelib.xml");
 		}
 	}
 

--- a/project.json
+++ b/project.json
@@ -1,5 +1,12 @@
 {
-	"name":"MassiveCover",
-	"version":"1.4.2",
-	"id":"mcover"
+	"project": 
+	{
+		"name": "MassiveCover",
+		"version": "1.5.0",
+		"id": "mcover"
+	},
+	"haxelib":
+	{
+		"user": "massive"
+	}
 }

--- a/src/AllClasses.hx
+++ b/src/AllClasses.hx
@@ -1,35 +1,6 @@
-/****
-* Copyright 2012 Massive Interactive. All rights reserved.
-* 
-* Redistribution and use in source and binary forms, with or without modification, are
-* permitted provided that the following conditions are met:
-* 
-*    1. Redistributions of source code must retain the above copyright notice, this list of
-*       conditions and the following disclaimer.
-* 
-*    2. Redistributions in binary form must reproduce the above copyright notice, this list
-*       of conditions and the following disclaimer in the documentation and/or other materials
-*       provided with the distribution.
-* 
-* THIS SOFTWARE IS PROVIDED BY MASSIVE INTERACTIVE ``AS IS'' AND ANY EXPRESS OR IMPLIED
-* WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
-* FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL MASSIVE INTERACTIVE OR
-* CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-* ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
-* ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-* 
-* The views and conclusions contained in the software and documentation are those of the
-* authors and should not be interpreted as representing official policies, either expressed
-* or implied, of Massive Interactive.
-****/
-
 package ;
 
 import m.cover.MCover;
-import m.cover.munit.client.MCoverPrintClient;
 import mcover.coverage.client.EMMAPrintClient;
 import mcover.coverage.client.PrintClient;
 import mcover.coverage.client.TraceClient;

--- a/src/haxelib.xml
+++ b/src/haxelib.xml
@@ -1,7 +1,7 @@
 <project name="mcover" url="http://github.com/massiveinteractive/mcover" license="MIT">
 	<user name="massive"/>
 	<description><![CDATA[A cross platform code coverage framework for Haxe with testing and profiling applications. Supports AVM1, AVM2, JavaScript, C++, PHP and Neko.]]></description>
-	<version name="1.4.2"><![CDATA[Minor tweaks to support haxe svn (2.11). See CHANGES for details.]]></version>
+	<version name="1.5.0"><![CDATA[Added better handling/support for coverage of macro generated functions/code blocks]]></version>
 	<depends name="mconsole"/>
 	<tag v="cross"/>
 	<tag v="macro"/>

--- a/src/mcover/coverage/macro/CoverageExpressionParser.hx
+++ b/src/mcover/coverage/macro/CoverageExpressionParser.hx
@@ -235,6 +235,7 @@ import sys.FileSystem;
 
 		file = FileSystem.fullPath(file);
 
+		var posFile = Context.resolvePath(posInfo.file);
 		var classFile = FileSystem.fullPath(Context.resolvePath(target.info.fileName));
 
 		if(file != classFile)
@@ -246,6 +247,7 @@ import sys.FileSystem;
 
 		for (cp in CoverageMacroDelegate.classPathHash)
 		{
+
 			if(file.indexOf(cp) == 0)
 			{	
 				if(strict)
@@ -284,22 +286,39 @@ import sys.FileSystem;
 					info.methodName = target.info.methodName;
 				}
 				
-				return createReference(cp, file, startPos, endPos, isBranch, info, alternateLocation);
+				return createReference(cp, file, startPos, endPos, isBranch, info, alternateLocation, true);
 			}
 		}
 
-		var error = "Unable to find file in any class paths (" + file + ") " + Std.string(startPos);
-		error += "\n    " + target.info.location;
+
+		//At this point it is likely that the method/block was generated via macros
+		//and has different position info to the target class being parsed.
 		for (cp in CoverageMacroDelegate.classPathHash)
 		{
-			error += "\n   " + cp;
+			if(classFile.indexOf(cp) == 0)
+			{
+				file = classFile;
+				var alternateLocation:String = posFile;
+
+				return createReference(cp, file, startPos, endPos, isBranch, target.info, alternateLocation, true);
+			}
+		}
+
+		
+		var error = "Unable to find referenced file (" + file + ") or target file (" + classFile + ") in any class paths.";
+		error += "\n    Location: " + target.info.location;
+		error += "\n    Referenced pos: " + Std.string(startPos);
+		error += "\n    Searched classpaths:";
+		for (cp in CoverageMacroDelegate.classPathHash)
+		{
+			error += "\n      " + cp;
 		}
 		Context.error(error, Context.currentPos());
 		throw new CoverageException(error);
 		return null;
 	}
 
-	function createReference(cp:String, file:String, startPos:Position, endPos:Position, isBranch:Bool, ?info:ClassInfo, ?alternateLocation:String):AbstractBlock
+	function createReference(cp:String, file:String, startPos:Position, endPos:Position, isBranch:Bool, ?info:ClassInfo, ?alternateLocation:String, ?generatedByMacro:Bool=false):AbstractBlock
 	{
 		if(info == null) info = target.info;
 
@@ -359,6 +378,9 @@ import sys.FileSystem;
 			p.shift();
 
 			block.location = alternateLocation + ":" + p.join(":");
+
+			if(generatedByMacro)
+				block.location += " @:macro";
 		}
 		else
 		{

--- a/src/mcover/macro/ClassPathFilter.hx
+++ b/src/mcover/macro/ClassPathFilter.hx
@@ -198,7 +198,6 @@ class ClassPathFilter
 		{
 			var ignoreClassMetas = "(" + ignoreClassMeta.split(",").join("|") + ")";//e.g. :(IgnoreCover|:IgnoreCover|:ignore|:macro)
 
-			trace("ignoreClassMetas: " + ignoreClassMetas);
 			temp = contents;
 			//var regIgnore:EReg = ~/@IgnoreCover([^{]*)class ([A-Z]([A-Za-z0-9])+)/m;
 			var regIgnore:EReg = new EReg("@" + ignoreClassMetas + "([^{]*)class ([A-Z]([A-Za-z0-9_])+)", "m");


### PR DESCRIPTION
### Background

Functions generated via macros using `@:autoBuild` used to throw a compilation errors due to overly restrictive validation when there was a mismatch between the class file and the one referenced in the expr.pos of the generated code.

The previous work around was to override the @:autoBuild by declaring a @:build directly on the class effected.
### Changes

This release improves handling of this scenario:
- Updates coverage information to support expr.pos file path outside of the current class
- Adds a `@:macro` to the printed output of  coverage blocks that contain position info outside of the class file path
- Only throw exception when neither the expr.pos file nor the class file can be located inside any of the coverage class paths.
