### PR TITLE
removed folder name from file node in EmmaPrintClient

### DIFF
--- a/src/mcover/coverage/client/EMMAPrintClient.hx
+++ b/src/mcover/coverage/client/EMMAPrintClient.hx
@@ -54,7 +54,7 @@ class EMMAPrintClient implements CoverageReportClient
 		xml = Xml.createElement("report");
 
 		
-        this.coverage = coverage;
+		this.coverage = coverage;
 		
 		result = coverage.getResults();		
 		
@@ -149,26 +149,26 @@ class EMMAPrintClient implements CoverageReportClient
 		return node;
 	}
 
-    private function baseName (path : String) : String
-    {
-        var parts : Array<String> = path.split ("/");
-        if (parts.length < 1)
-        {
-            return path;
-        }
-        var lastPart : String = parts [parts.length -1];
-        if (lastPart.length <= 0)
-        {
-            return path;
-        }
-        return lastPart;
-    }
+	private function baseName(path:String) : String
+	{
+		var parts:Array<String> = path.split("/");
+		if(parts.length < 1)
+		{
+			return path;
+		}
+		var lastPart:String = parts[parts.length -1];
+		if(lastPart.length <= 0)
+		{
+			return path;
+		}
+		return lastPart;
+	}
 
 	function createFileNode(file:File):Xml
 	{
         // Jenkins EMMA-Plugin does not support relative path names in "srcfile"
         // use baseName to just put the filename in srcfile
-		var node = createNodeWithName("srcfile", baseName (file.name));
+		var node = createNodeWithName("srcfile", baseName(file.name));
 
 		var result = file.getResults();
 

--- a/src/mcover/coverage/client/EMMAPrintClient.hx
+++ b/src/mcover/coverage/client/EMMAPrintClient.hx
@@ -53,7 +53,6 @@ class EMMAPrintClient implements CoverageReportClient
 	{
 		xml = Xml.createElement("report");
 
-		
 		this.coverage = coverage;
 		
 		result = coverage.getResults();		
@@ -166,8 +165,8 @@ class EMMAPrintClient implements CoverageReportClient
 
 	function createFileNode(file:File):Xml
 	{
-        // Jenkins EMMA-Plugin does not support relative path names in "srcfile"
-        // use baseName to just put the filename in srcfile
+		// Jenkins EMMA-Plugin does not support relative path names in "srcfile"
+		// use baseName to just put the filename in srcfile
 		var node = createNodeWithName("srcfile", baseName(file.name));
 
 		var result = file.getResults();

--- a/src/mcover/coverage/client/EMMAPrintClient.hx
+++ b/src/mcover/coverage/client/EMMAPrintClient.hx
@@ -28,6 +28,8 @@
 
 package mcover.coverage.client;
 
+import haxe.io.Path;
+
 import mcover.coverage.CoverageReportClient;
 import mcover.coverage.DataTypes;
 
@@ -148,26 +150,11 @@ class EMMAPrintClient implements CoverageReportClient
 		return node;
 	}
 
-	private function baseName(path:String) : String
-	{
-		var parts:Array<String> = path.split("/");
-		if(parts.length < 1)
-		{
-			return path;
-		}
-		var lastPart:String = parts[parts.length -1];
-		if(lastPart.length <= 0)
-		{
-			return path;
-		}
-		return lastPart;
-	}
-
 	function createFileNode(file:File):Xml
 	{
 		// Jenkins EMMA-Plugin does not support relative path names in "srcfile"
 		// use baseName to just put the filename in srcfile
-		var node = createNodeWithName("srcfile", baseName(file.name));
+		var node = createNodeWithName("srcfile", Path.withoutDirectory(file.name));
 
 		var result = file.getResults();
 

--- a/src/mcover/coverage/client/EMMAPrintClient.hx
+++ b/src/mcover/coverage/client/EMMAPrintClient.hx
@@ -53,7 +53,8 @@ class EMMAPrintClient implements CoverageReportClient
 	{
 		xml = Xml.createElement("report");
 
-		this.coverage = coverage;
+		
+        this.coverage = coverage;
 		
 		result = coverage.getResults();		
 		
@@ -148,9 +149,26 @@ class EMMAPrintClient implements CoverageReportClient
 		return node;
 	}
 
+    private function baseName (path : String) : String
+    {
+        var parts : Array<String> = path.split ("/");
+        if (parts.length < 1)
+        {
+            return path;
+        }
+        var lastPart : String = parts [parts.length -1];
+        if (lastPart.length <= 0)
+        {
+            return path;
+        }
+        return lastPart;
+    }
+
 	function createFileNode(file:File):Xml
 	{
-		var node = createNodeWithName("srcfile", file.name);
+        // Jenkins EMMA-Plugin does not support relative path names in "srcfile"
+        // use baseName to just put the filename in srcfile
+		var node = createNodeWithName("srcfile", baseName (file.name));
 
 		var result = file.getResults();
 

--- a/src/mcover/coverage/client/EMMAPrintClient.hx
+++ b/src/mcover/coverage/client/EMMAPrintClient.hx
@@ -153,7 +153,6 @@ class EMMAPrintClient implements CoverageReportClient
 	function createFileNode(file:File):Xml
 	{
 		// Jenkins EMMA-Plugin does not support relative path names in "srcfile"
-		// use baseName to just put the filename in srcfile
 		var node = createNodeWithName("srcfile", Path.withoutDirectory(file.name));
 
 		var result = file.getResults();

--- a/src/mcover/macro/ClassParser.hx
+++ b/src/mcover/macro/ClassParser.hx
@@ -234,6 +234,10 @@ class ClassParserImpl implements ClassParser
 
 		for(parser in fieldParsers)
 		{
+            if (Std.string (expr.pos) == "#pos((unknown))")
+            {
+                continue;
+            }
 			expr = parser.parseExpr(expr);
 		}
 

--- a/src/mcover/util/Timer.hx
+++ b/src/mcover/util/Timer.hx
@@ -148,7 +148,7 @@ class Timer
 				var shouldStop = false;
 				while( !shouldStop )
 				{
-					Sys.sleep(time_ms/1000);
+					//Sys.sleep(time_ms/1000);
 					try
 					{
 						run();


### PR DESCRIPTION
Hi,

when using EMMAPrintClient with JenkinsCI I could not click through to the function level, because  `file.name` also contains the source folder. Using just the filename makes Jenkins show a coverage overview of all classes and functions inside that file.
