### PR TITLE
Fix backslashes missing (or blowing up) on Windows

### DIFF
--- a/src/mcover/coverage/macro/CoverageExpressionParser.hx
+++ b/src/mcover/coverage/macro/CoverageExpressionParser.hx
@@ -391,6 +391,11 @@ import sys.FileSystem;
 
 		if(alternateLocation != null)
 		{
+			// because of double eval() call later in JS part
+			// single '\' were being removed
+			// or code was blowing up (if '\u')
+			if(IS_WINDOWS) alternateLocation = alternateLocation.split("\\").join("\\\\\\\\");
+
 			// match everything before line number as path
 			// we can't simply split on ":" because
 			// on windows, paths contain ":" 


### PR DESCRIPTION
I was getting an error while trying to run unit tests for JS target.

```
Uncaught SyntaxError: Invalid Unicode escape sequence
    at massive_munit_client_ExternalPrintClientJS.queue (js_test.js:6799)
    at massive_munit_client_ExternalPrintClientJS.addTestClassCoverageItem (js_test.js:6768)
    at massive_munit_client_RichPrintClient.setCurrentTestClassCoverage (js_test.js:6948)
    at mcover_coverage_munit_client_MCoverPrintClient.updateTestClassCoverage (js_test.js:9429)
    at mcover_coverage_munit_client_MCoverPrintClient.setCurrentTestClass (js_test.js:9397)
    at massive_munit_TestRunner.execute (js_test.js:5730)
    at massive_munit_TestRunner.run (js_test.js:5695)
    at delayStartup (js_test.js:369)
    at TestMain [as __class__] (js_test.js:373)
    at Function.TestMain.main (js_test.js:378)
```

After bit of digging I found that it's blowing up in [PrintClientBase.hx#L510](https://github.com/massiveinteractive/MassiveUnit/blob/master/src/massive/munit/client/PrintClientBase.hx#L510).

Seems like my `utils` package was causing `eval()` issues because of `\u`.
After even more digging I finally found place where I can fix it, I came here to do a fork so i can PR and (surprise, surprise) I found [THIS COMMIT](https://github.com/massiveinteractive/mcover/commit/d46931bc71684ed62b7535947cb29fdcb14d41e1).
I think it was accidentally removed in this commit while fixing split on windows, but looks like this replace line is still needed before using regex. And just `"\\\\"` are not enough, because `eval()` is called again in [printclient.js#L51](https://github.com/massiveinteractive/MassiveUnit/blob/master/src/resource/js/printclient.js#L51).


On top of that this PR should also fix https://github.com/massiveinteractive/mcover/issues/36

Regards :)