### PR TITLE
fixed line number detection

### DIFF
--- a/src/mcover/coverage/macro/CoverageExpressionParser.hx
+++ b/src/mcover/coverage/macro/CoverageExpressionParser.hx
@@ -58,8 +58,8 @@ import sys.FileSystem;
 
 	public var target(default, default):ClassParser;
 
-	static var posReg:EReg = ~/([a-zA-z0-9\/].*.hx):([0-9].*): (characters|lines) ([0-9].*)-([0-9].*)/;
-	
+	static var posReg:EReg = ~/([a-zA-Z0-9\/]+\.hx):([0-9]+): (chars|lines) ([0-9]+)-([0-9]+)/;
+
 	var coveredLines:IntMap<Bool>;
 	var exprPos:Position;
 
@@ -418,6 +418,7 @@ import sys.FileSystem;
 
 		posString = Std.string(endPos);
 		posString = posString.substr(5, posString.length-6);
+		posString = posString.split(" characters ").join(" chars ");
 
 		if(posReg.match(posString))
 		{


### PR DESCRIPTION
Replacing `chararacters` with `chars` was only done for `startLine`, not `endLine`. 
So `startLine` would never match `posReg` regex with position strings containing `characters`, and usually end up as `-1`.

I also adjusted `posReg`, but I'm not sure, if those `.*` were in there because of some systems/targets reporting weird numbers...
 