### PR TITLE
Add lcov printclient

### DIFF
--- a/hxformat.json
+++ b/hxformat.json
@@ -1,0 +1,3 @@
+{
+    "disableFormatting": true
+}

--- a/src/mcover/coverage/client/CodecovJsonPrintClient.hx
+++ b/src/mcover/coverage/client/CodecovJsonPrintClient.hx
@@ -1,0 +1,130 @@
+package mcover.coverage.client;
+
+#if sys
+import haxe.Json;
+import sys.io.FileOutput;
+import mcover.coverage.CoverageReportClient;
+import mcover.coverage.DataTypes;
+import mcover.util.Timer;
+
+class CodecovJsonPrintClient implements CoverageReportClient {
+	public var completionHandler(default, default):CoverageReportClient->Void;
+	public var output(default, null):String;
+
+	var coverageFileName:String;
+
+	public function new(?fileName:String) 
+	{
+		if(fileName == null) 
+		{
+			coverageFileName = "coverage.json";
+		} 
+		else
+		{
+			coverageFileName = fileName;
+		}
+	}
+
+	public function report(coverage:Coverage) 
+	{
+		var text:StringBuf = new StringBuf();
+		text.add("{\n\t\"coverage\": {\n");
+
+		var first:Bool = true;
+		for (cls in coverage.getClasses()) 
+		{
+			if (!first) 
+			{
+				text.add(",\n");
+			}
+			text.add(reportClass(cls));
+			first = false;
+		}
+		text.add("\n\t}\n}\n");
+
+		var file:FileOutput = sys.io.File.write(coverageFileName);
+		file.writeString(text.toString());
+		file.close();
+
+		#if (php||eval)
+			reportComplete();
+		#else
+			var timer = Timer.delay(reportComplete, 10);
+		#end
+	}
+
+	function reportComplete()
+	{
+		if(completionHandler != null)
+		{
+			completionHandler(this);
+		}
+	}
+
+	function reportClass(cls:Clazz):String {
+		var c = StringTools.replace(cls.name, ".", "/") + ".hx";
+		var text:StringBuf = new StringBuf();
+		text.add('\t\t"$c": {\n');
+
+		var lineCov:Map<Int, String> = new Map<Int, String>();
+		var maxLineNumber:Int = 0;
+		for (method in cls.getMethods()) {
+			var max:Int = reportMethod(text, method, lineCov);
+			if (max > maxLineNumber) {
+				maxLineNumber = max;
+			}
+		}
+		var first:Bool = true;
+		for (line in 0...maxLineNumber + 1) {
+			if (!lineCov.exists(line)) {
+				continue;
+			}
+			if (!first) {
+				text.add(",\n");
+			}
+			first = false;
+			var count = lineCov.get(line);
+			text.add('\t\t\t"$line": $count');
+		}
+		text.add("\n\t\t}");
+		return text.toString();
+	}
+
+	@:access(mcover.coverage.data.Method)
+	function reportMethod(text:StringBuf, method:Method, lineCov:Map<Int, String>):Int {
+		var maxLineNumber:Int = 0;
+
+		for (statementId in method.statementsById.keys()) {
+			var statement:Statement = method.statementsById.get(statementId);
+			for (line in statement.lines) {
+				maxLineNumber = addLineCov(line, lineCov, '${statement.count}', maxLineNumber);
+			}
+		}
+		for (branchId in method.branchesById.keys()) {
+			var branch:Branch = method.branchesById.get(branchId);
+			if (branch.isCovered()) {
+				for (line in branch.lines) {
+					maxLineNumber = addLineCov(line, lineCov, "1", maxLineNumber);
+				}
+			} else {
+				var coverage:String = "\"1/2\"";
+				if (branch.totalCount <= 0) {
+					coverage = "0";
+				}
+				for (line in branch.lines) {
+					maxLineNumber = addLineCov(line, lineCov, coverage, maxLineNumber);
+				}
+			}
+		}
+		return maxLineNumber;
+	}
+
+	function addLineCov(line:Int, lineCov:Map<Int, String>, count:String, maxLineNumber:Int):Int {
+		if (line > maxLineNumber) {
+			maxLineNumber = line;
+		}
+		lineCov.set(line, count);
+		return maxLineNumber;
+	}
+}
+#end

--- a/src/mcover/coverage/client/LcovPrintClient.hx
+++ b/src/mcover/coverage/client/LcovPrintClient.hx
@@ -1,0 +1,188 @@
+package mcover.coverage.client;
+
+#if sys
+import sys.io.FileOutput;
+import mcover.coverage.CoverageReportClient;
+import mcover.coverage.DataTypes;
+import mcover.util.Timer;
+
+class LcovPrintClient implements CoverageReportClient {
+
+	public var completionHandler(default, default):CoverageReportClient->Void;
+	public var output(default, null):String;
+
+	var testName:String;
+	var lcovFileName:String;
+
+	public function new(name:String, ?fileName:String) {
+		testName = name;
+		if (fileName == null) 
+		{
+			lcovFileName = "lcov.info";
+		} 
+		else
+		{
+			lcovFileName = fileName;
+		}
+	}
+
+	public function report(coverage:Coverage) {
+		sys.io.File.saveContent(lcovFileName, makeLine("TN", testName) + "\n");
+
+		for (cls in coverage.getClasses()) {
+			reportClass(cls);
+		}
+	
+		#if (php||eval)
+			reportComplete();
+		#else
+			var timer = Timer.delay(reportComplete, 10);
+		#end
+	}
+
+	function reportComplete()
+	{
+		if(completionHandler != null)
+		{
+			completionHandler(this);
+		}
+	}
+
+	function reportClass(cls:Clazz) {
+		var results:CoverageResult = cls.getResults();
+		var c = StringTools.replace(cls.name, ".", "/") + ".hx";
+		var text:StringBuf = new StringBuf();
+		text.add(makeLine("SF", c));
+		text.add("\n");
+
+		var lineCov:Map<Int, Int> = new Map<Int, Int>();
+		var branchCov:Map<Int, String> = new Map<Int, String>();
+		var maxLineNumber:Int = 0;
+
+		var num:Int = 0;
+		for (method in cls.getMethods()) {
+			// TODO get first line number of method
+			text.add(makeLine("FN", '${num++},${method.name}'));
+		}
+		text.add("\n");
+
+		for (method in cls.getMethods()) {
+			var methodResults:CoverageResult = method.getResults();
+			text.add(makeLine("FNDA", '${methodResults.m},${method.name}'));
+		}
+		text.add("\n");
+		text.add(makeLine("FNF", '${results.m}'));
+		text.add(makeLine("FNH", '${results.mc}'));
+		text.add("\n");
+
+		maxLineNumber = 0;
+		for (method in cls.getMethods()) {
+			var max:Int = reportBranches(text, method, branchCov);
+			if (max > maxLineNumber) {
+				maxLineNumber = max;
+			}
+		}
+		for (line in 0...maxLineNumber + 1) {
+			if (!branchCov.exists(line)) {
+				continue;
+			}
+			var count:String = branchCov.get(line);
+			text.add(makeLine("BRDA", '${line},${count}'));
+		}
+
+		text.add("\n");
+		text.add(makeLine("BRF", '${results.b}'));
+		text.add(makeLine("BRH", '${results.bt}'));
+		text.add("\n");
+
+		maxLineNumber = 0;
+		for (method in cls.getMethods()) {
+			var max:Int = reportStatements(text, method, lineCov);
+			if (max > maxLineNumber) {
+				maxLineNumber = max;
+			}
+		}
+		for (line in 0...maxLineNumber + 1) {
+			if (!lineCov.exists(line)) {
+				continue;
+			}
+			var count:Int = lineCov.get(line);
+			text.add(makeLine("DA", '${line},${count}'));
+		}
+		text.add("\n");
+
+		text.add(makeLine("LF", '${results.l}'));
+		text.add(makeLine("LH", '${results.lc}'));
+		text.add("\n");
+
+		text.add("end_of_record\n\n");
+		appendCoverageFile(text.toString());
+	}
+
+	@:access(mcover.coverage.data.Method)
+	function reportStatements(text:StringBuf, method:Method, lineCov:Map<Int, Int>):Int {
+		var maxLineNumber:Int = 0;
+
+		for (statementId in method.statementsById.keys()) {
+			var statement:Statement = method.statementsById.get(statementId);
+			for (line in statement.lines) {
+				maxLineNumber = addLineCov(line, lineCov, statement.count, maxLineNumber);
+			}
+		}
+		for (branchId in method.branchesById.keys()) {
+			var branch:Branch = method.branchesById.get(branchId);
+			if (branch.isCovered()) {
+				for (line in branch.lines) {
+					maxLineNumber = addLineCov(line, lineCov, 1, maxLineNumber);
+				}
+			} else {
+				for (line in branch.lines) {
+					maxLineNumber = addLineCov(line, lineCov, branch.totalCount, maxLineNumber);
+				}
+			}
+		}
+		return maxLineNumber;
+	}
+
+	@:access(mcover.coverage.data.Method)
+	function reportBranches(text:StringBuf, method:Method, branchCov:Map<Int, String>):Int {
+		var maxLineNumber:Int = 0;
+
+		for (branchId in method.branchesById.keys()) {
+			var branch:Branch = method.branchesById.get(branchId);
+			var data:String = '${method.id},${branch.id},${branch.totalCount}';
+			if (branch.isCovered()) {
+				for (line in branch.lines) {
+					maxLineNumber = addLineCov(line, branchCov, data, maxLineNumber);
+				}
+			} else {
+				for (line in branch.lines) {
+					if (branch.isPartiallyCovered()) {
+						data = '${method.id},${branch.id},-';
+					}
+					maxLineNumber = addLineCov(line, branchCov, data, maxLineNumber);
+				}
+			}
+		}
+		return maxLineNumber;
+	}
+
+	function addLineCov<T>(line:Int, lineCov:Map<Int, T>, count:T, maxLineNumber:Int):Int {
+		if (line > maxLineNumber) {
+			maxLineNumber = line;
+		}
+		lineCov.set(line, count);
+		return maxLineNumber;
+	}
+
+	function appendCoverageFile(text:String) {
+		var file:FileOutput = sys.io.File.append(lcovFileName);
+		file.writeString(text.toString());
+		file.close();
+	}
+
+	inline function makeLine(key:String, value:String):String {
+		return '$key:$value\n';
+	}
+}
+#end

--- a/src/mcover/coverage/macro/CoverageExpressionParser.hx
+++ b/src/mcover/coverage/macro/CoverageExpressionParser.hx
@@ -58,8 +58,8 @@ import sys.FileSystem;
 
 	public var target(default, default):ClassParser;
 
-	static var posReg:EReg = ~/([a-zA-z0-9\/].*.hx):([0-9].*): (characters|lines) ([0-9].*)-([0-9].*)/;
-	
+	static var posReg:EReg = ~/([a-zA-Z0-9\/]+\.hx):([0-9]+): (chars|lines) ([0-9]+)-([0-9]+)/;
+
 	var coveredLines:IntMap<Bool>;
 	var exprPos:Position;
 
@@ -418,6 +418,7 @@ import sys.FileSystem;
 
 		posString = Std.string(endPos);
 		posString = posString.substr(5, posString.length-6);
+		posString = posString.split(" characters ").join(" chars ");
 
 		if(posReg.match(posString))
 		{

--- a/test/TestMain.hx
+++ b/test/TestMain.hx
@@ -29,6 +29,9 @@ class TestMain
 		#if MCOVER
 			var client = new mcover.coverage.munit.client.MCoverPrintClient();
 			var httpClient = new HTTPClient(new mcover.coverage.munit.client.MCoverSummaryReportClient());
+			#if sys
+				mcover.coverage.MCoverage.getLogger().addClient(new mcover.coverage.client.LcovPrintClient("mcover unittests"));
+			#end
 		#else
 			var client = new RichPrintClient();
 			var httpClient = new HTTPClient(new SummaryReportClient());


### PR DESCRIPTION
Added lcov and codecov print clients.

`CodecovJsonPrintClient` generates a file named `coverage.json` that works with codegov.io service (sample: https://codecov.io/gh/HaxeCheckstyle/haxe-formatter). It's a rewrite of code that haxe-checkstyle has used for a few years.

`LcovPrintClient` produces a `lcov.info` file that works with `coverage-gutters` extension in VSCode, so you can visualize coverage per file (sample https://imgur.com/a/WrqHDtH). You can also use other lcov tools on it (e.g. genhtml)

Includes my previous PRs, because haxe-formatter and haxe-checkstyle rely on new print clients, and they need at least the line number patch to report correct numbers.