### PR TITLE
fixed absolute path names

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# This file is for unifying the coding style for different editors and IDEs.
+# More information at http://EditorConfig.org
+root = true
+
+[*]
+indent_style = tab
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.hx]
+end_of_line = lf
+charset = utf-8
+
+[*.md]
+indent_style = space
+indent_size = 2
+
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/src/mcover/coverage/client/LcovPrintClient.hx
+++ b/src/mcover/coverage/client/LcovPrintClient.hx
@@ -1,16 +1,16 @@
 /****
 * Copyright 2019 Massive Interactive. All rights reserved.
-* 
+*
 * Redistribution and use in source and binary forms, with or without modification, are
 * permitted provided that the following conditions are met:
-* 
+*
 *    1. Redistributions of source code must retain the above copyright notice, this list of
 *       conditions and the following disclaimer.
-* 
+*
 *    2. Redistributions in binary form must reproduce the above copyright notice, this list
 *       of conditions and the following disclaimer in the documentation and/or other materials
 *       provided with the distribution.
-* 
+*
 * THIS SOFTWARE IS PROVIDED BY MASSIVE INTERACTIVE ``AS IS'' AND ANY EXPRESS OR IMPLIED
 * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
 * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL MASSIVE INTERACTIVE OR
@@ -20,7 +20,7 @@
 * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-* 
+*
 * The views and conclusions contained in the software and documentation are those of the
 * authors and should not be interpreted as representing official policies, either expressed
 * or implied, of Massive Interactive.
@@ -28,19 +28,11 @@
 
 package mcover.coverage.client;
 
-#if macro
-import haxe.macro.Expr;
-import haxe.macro.Context;
-#end
-
 #if (sys || nodejs)
-import haxe.io.Path;
 import sys.io.FileOutput;
-import sys.FileSystem;
 import mcover.coverage.CoverageReportClient;
 import mcover.coverage.DataTypes;
 import mcover.util.Timer;
-
 
 class LcovPrintClient implements CoverageReportClient {
 
@@ -65,8 +57,17 @@ class LcovPrintClient implements CoverageReportClient {
 
 	public function report(coverage:Coverage) {
 		sys.io.File.saveContent(lcovFileName, "\n");
+
+		var fileClassMap:Map<String, Array<Clazz>>=new Map<String, Array<Clazz>>();
 		for (cls in coverage.getClasses()) {
-			reportClass(cls);
+			var path = getAbsolutePath(cls);
+			if (fileClassMap.exists(path)) {
+				fileClassMap.get(path).push(cls);continue;
+			}
+			fileClassMap.set(path, [cls]);
+		}
+		for (path in fileClassMap.keys()) {
+			reportFile(path, fileClassMap.get(path));
 		}
 
 		#if (php||eval)
@@ -84,58 +85,37 @@ class LcovPrintClient implements CoverageReportClient {
 		}
 	}
 
-    macro public static function getClassPaths():Expr
-    {
-		var classPaths:Array<String> = Context.getClassPath();
-        return macro $v{classPaths};
-    }
-
-    macro public static function getCompileCwd():Expr
-    {
-		var cwd:String = Sys.getCwd();
-		return macro $v{cwd};
-    }
-
-	function makeAbsolutePath(path:String):String {
-		if (Path.isAbsolute(path)) {
-			return path;
-		}
-		var classPaths:Array<String> = getClassPaths();
-		var cwd:String = getCompileCwd();
-		var fullPath:String;
-		var lastKnown:String;
-		for (cp in classPaths) {
-			if (Path.isAbsolute(cp)) {
-				fullPath = Path.join([cp, path]);
-				lastKnown= cp;
-			} else {
-				fullPath = Path.join([cwd, cp, path]);
-				lastKnown = Path.join([cwd, cp]);
-			}
-			if (FileSystem.exists(fullPath)) {
-				lastKnownAbsoluteBasePath = lastKnown;
-				return fullPath;
+	@:access(mcover.coverage.data.AbstractNodeList)
+	@:access(mcover.coverage.data.Method)
+	function getAbsolutePath(cls:Clazz):String {
+		for (item in cls.itemsById) {
+			if (Type.getClass(item) == Method){
+				var method:Method = cast item;
+				for (branch in method.branchesById) {
+					return locationToPath(branch.location);
+				}
+				for (stmt in method.statementsById) {
+					return locationToPath(stmt.location);
+				}
 			}
 		}
-		fullPath = Path.join([cwd, path]);
-		if (FileSystem.exists(fullPath)) {
-			return fullPath;
-		}
-		if (lastKnownAbsoluteBasePath != null) {
-			// multiple types inside a single file will not match a simple class -> file mapping
-			return Path.join([lastKnownAbsoluteBasePath, path]);
-		}
-		return path;
+		return StringTools.replace(cls.name, ".", "/") + ".hx";
 	}
 
-	function reportClass(cls:Clazz) {
-		var results:CoverageResult = cls.getResults();
-		// TODO find a better solution to get absolute file path
-		var c = makeAbsolutePath(StringTools.replace(cls.name, ".", "/") + ".hx");
+	function locationToPath(location:String):String {
+		var index:Int = location.lastIndexOf(".hx:");
+		if (index < 0) {
+			return location;
+		}
+		return location.substr(0, index + 3);
+	}
+
+	function reportFile(path:String, classes:Array<Clazz>){
+
 		var text:StringBuf = new StringBuf();
 
-		text.add(makeLine("TN", cls.name));
-		text.add(makeLine("SF", c));
+		text.add(makeLine("TN", classes[0].name));
+		text.add(makeLine("SF", path));
 		text.add("\n");
 
 		var lineCov:Map<Int, Int> = new Map<Int, Int>();
@@ -143,24 +123,38 @@ class LcovPrintClient implements CoverageReportClient {
 		var maxLineNumber:Int = 0;
 
 		var num:Int = 0;
-		for (method in cls.getMethods()) {
-			text.add(makeLine("FN", '${firstMethodLine(method)},${method.name}'));
+		for (cls in classes) {
+			for (method in cls.getMethods()) {
+				text.add(makeLine("FN", '${firstMethodLine(method)},${method.name}'));
+			}
 		}
 		text.add("\n");
 
-		for (method in cls.getMethods()) {
-			text.add(makeLine("FNDA", '${methodCount(method)},${method.name}'));
+		for (cls in classes) {
+			for (method in cls.getMethods()) {
+				text.add(makeLine("FNDA", '${methodCount(method)},${method.name}'));
+			}
 		}
+
 		text.add("\n");
-		text.add(makeLine("FNF", '${results.m}'));
-		text.add(makeLine("FNH", '${results.mc}'));
+		var countF:Int = 0;
+		var countH:Int = 0;
+		for (cls in classes) {
+			var results:CoverageResult = cls.getResults();
+			countF += results.m;
+			countH += results.mc;
+		}
+		text.add(makeLine("FNF", '$countF'));
+		text.add(makeLine("FNH", '$countH'));
 		text.add("\n");
 
 		maxLineNumber = 0;
-		for (method in cls.getMethods()) {
-			var max:Int = reportBranches(text, method, branchCov);
-			if (max > maxLineNumber) {
-				maxLineNumber = max;
+		for (cls in classes) {
+			for (method in cls.getMethods()) {
+				var max:Int = reportBranches(text, method, branchCov);
+				if (max > maxLineNumber) {
+					maxLineNumber = max;
+				}
 			}
 		}
 		for (line in 0...maxLineNumber + 1) {
@@ -172,15 +166,24 @@ class LcovPrintClient implements CoverageReportClient {
 		}
 
 		text.add("\n");
-		text.add(makeLine("BRF", '${results.b}'));
-		text.add(makeLine("BRH", '${results.bt}'));
+		countF = 0;
+		countH = 0;
+		for (cls in classes) {
+			var results:CoverageResult = cls.getResults();
+			countF += results.b;
+			countH += results.bt;
+		}
+		text.add(makeLine("BRF", '$countF'));
+		text.add(makeLine("BRH", '$countH'));
 		text.add("\n");
 
 		maxLineNumber = 0;
-		for (method in cls.getMethods()) {
-			var max:Int = reportStatements(text, method, lineCov);
-			if (max > maxLineNumber) {
-				maxLineNumber = max;
+		for (cls in classes) {
+			for (method in cls.getMethods()) {
+				var max:Int = reportStatements(text, method, lineCov);
+				if (max > maxLineNumber) {
+					maxLineNumber = max;
+				}
 			}
 		}
 		for (line in 0...maxLineNumber + 1) {
@@ -190,10 +193,17 @@ class LcovPrintClient implements CoverageReportClient {
 			var count:Int = lineCov.get(line);
 			text.add(makeLine("DA", '${line},${count}'));
 		}
-		text.add("\n");
 
-		text.add(makeLine("LF", '${results.l}'));
-		text.add(makeLine("LH", '${results.lc}'));
+		text.add("\n");
+		countF = 0;
+		countH = 0;
+		for (cls in classes) {
+			var results:CoverageResult = cls.getResults();
+			countF += results.l;
+			countH += results.lc;
+		}
+		text.add(makeLine("LF", '$countF'));
+		text.add(makeLine("LH", '$countH'));
 		text.add("\n");
 
 		text.add("end_of_record\n\n");

--- a/src/mcover/coverage/client/LcovPrintClient.hx
+++ b/src/mcover/coverage/client/LcovPrintClient.hx
@@ -62,7 +62,8 @@ class LcovPrintClient implements CoverageReportClient {
 		for (cls in coverage.getClasses()) {
 			var path = getAbsolutePath(cls);
 			if (fileClassMap.exists(path)) {
-				fileClassMap.get(path).push(cls);continue;
+				fileClassMap.get(path).push(cls);
+				continue;
 			}
 			fileClassMap.set(path, [cls]);
 		}
@@ -324,9 +325,7 @@ class LcovPrintClient implements CoverageReportClient {
 
 	function appendCoverageFile(text:String) {
 		#if nodejs
-			var content:String = sys.io.File.getContent(lcovFileName);
-			content += text;
-			sys.io.File.saveContent(lcovFileName, content);
+			js.node.Fs.appendFileSync(lcovFileName, text);
 		#else
 			var file:FileOutput = sys.io.File.append(lcovFileName);
 			file.writeString(text.toString());

--- a/src/mcover/macro/ClassParser.hx
+++ b/src/mcover/macro/ClassParser.hx
@@ -257,7 +257,11 @@ class ClassParserImpl implements ClassParser
 				f.expr = parseExpr(f.expr);
 				expr.expr = EFunction(name, f);
 				functionStack.pop();
+<<<<<<< HEAD
 
+=======
+			
+>>>>>>> fixed absolute path names
 			case EDisplay(e, var isCall):
 				//no idea what this is???
 				e = parseExpr(e);

--- a/src/mcover/macro/ClassParser.hx
+++ b/src/mcover/macro/ClassParser.hx
@@ -1,16 +1,16 @@
 /****
 * Copyright 2019 Massive Interactive. All rights reserved.
-* 
+*
 * Redistribution and use in source and binary forms, with or without modification, are
 * permitted provided that the following conditions are met:
-* 
+*
 *    1. Redistributions of source code must retain the above copyright notice, this list of
 *       conditions and the following disclaimer.
-* 
+*
 *    2. Redistributions in binary form must reproduce the above copyright notice, this list
 *       of conditions and the following disclaimer in the documentation and/or other materials
 *       provided with the distribution.
-* 
+*
 * THIS SOFTWARE IS PROVIDED BY MASSIVE INTERACTIVE ``AS IS'' AND ANY EXPRESS OR IMPLIED
 * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
 * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL MASSIVE INTERACTIVE OR
@@ -20,7 +20,7 @@
 * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-* 
+*
 * The views and conclusions contained in the software and documentation are those of the
 * authors and should not be interpreted as representing official policies, either expressed
 * or implied, of Massive Interactive.
@@ -257,11 +257,7 @@ class ClassParserImpl implements ClassParser
 				f.expr = parseExpr(f.expr);
 				expr.expr = EFunction(name, f);
 				functionStack.pop();
-<<<<<<< HEAD
 
-=======
-			
->>>>>>> fixed absolute path names
 			case EDisplay(e, var isCall):
 				//no idea what this is???
 				e = parseExpr(e);


### PR DESCRIPTION
I've been playing around with VSCode extensions coverage-gutters and code-coverage to visualise coverage data in VSCode. coverage-gutters seems to be ok with current version of LcovPrintClient, but code-coverage can't work with paths generated from old version. New version uses or tries to use absolute paths and with those both extensions work expected.

Also added nodejs to supported targets.