### PR TITLE
fix typo warning on haxe 4

### DIFF
--- a/src/mcover/macro/ClassParser.hx
+++ b/src/mcover/macro/ClassParser.hx
@@ -258,7 +258,7 @@ class ClassParserImpl implements ClassParser
 				expr.expr = EFunction(name, f);
 				functionStack.pop();
 			
-			case EDisplay(e, isCall):
+			case EDisplay(e, var isCall):
 				//no idea what this is???
 				e = parseExpr(e);
 				expr.expr = EDisplay(e, isCall);


### PR DESCRIPTION
Haxe 4 gives the following warning when using the library:
```
mcover/src/mcover/macro/ClassParser.hx:261: characters 21-27 : Warning : Potential typo detected (expected similar values are DKCall). Consider using `var isCall` instead
```

Adding the var as mentioned fixes it.