### PR TITLE
Removed EDisplayNew

### DIFF
--- a/src/mcover/macro/ClassParser.hx
+++ b/src/mcover/macro/ClassParser.hx
@@ -376,10 +376,8 @@ class ClassParserImpl implements ClassParser
 			#if haxe3
 				case EUntyped(_): null;//don't want to mess around with untyped code
 				case EConst(_): null;//i.e. any constant (string, type, int, regex, ident (local var ref))
-				case EDisplayNew(_): null;  //no idea what this is??
 			#else
 				case EConst(c): null;//i.e. any constant (string, type, int, regex, ident (local var ref))
-				case EDisplayNew(r): null;  //no idea what this is??
 				case EType(e, field):
 					//e.g. Foo.bar;
 					e = parseExpr(e);


### PR DESCRIPTION
a recent Haxe commit removes EDisplayNew and since it was never really used / supported by mcover it should be safe to drop it for all versions and let `default` handle it.