### PR TITLE
Move haxelib.json to project root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,3 @@ bin
 lcov.info
 
 .haxelib
-/haxelib.json

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## 2.3.0
+
+- Removed `EDisplayNew` which is now removed in Haxe 4.3
+- Moved `haxelib.json` to the root of the repository, so that it can be added as a git haxelib dependency
+- Replaced the deprecated `@:extern` metadata with the `extern` keyword
+
 ## 2.2.2
 
 - LcovPrintClient improvements

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 set -e
 
-haxelib dev mcover `pwd`/src
+haxelib dev mcover `pwd`
 
 mkdir -p bin
 mkdir -p bin/output

--- a/haxelib.json
+++ b/haxelib.json
@@ -2,20 +2,20 @@
 	"name": "mcover",
 	"license": "MIT",
 	"tags": [
-	"cross",
-	"macro",
-	"utility",
-	"massive"
-],
+		"cross",
+		"macro",
+		"utility",
+		"massive"
+	],
 	"description": "A cross platform code coverage framework for Haxe with testing and profiling applications. Supports AVM1, AVM2, JavaScript, C++, PHP and Neko.",
 	"contributors": [
-	"massive"
-],
+		"massive"
+	],
 	"releasenote": "See CHANGES.md in the repository",
-	"version": "2.2.2",
+	"version": "2.3.0",
+	"classPath": "src",
 	"url": "http://github.com/massiveinteractive/mcover",
-	"dependencies":
-	{
+	"dependencies": {
 		"mconsole": "",
 		"munit": ""
 	}

--- a/src/mcover/coverage/client/PrintClient.hx
+++ b/src/mcover/coverage/client/PrintClient.hx
@@ -1,16 +1,16 @@
 /****
 * Copyright 2019 Massive Interactive. All rights reserved.
-* 
+*
 * Redistribution and use in source and binary forms, with or without modification, are
 * permitted provided that the following conditions are met:
-* 
+*
 *    1. Redistributions of source code must retain the above copyright notice, this list of
 *       conditions and the following disclaimer.
-* 
+*
 *    2. Redistributions in binary form must reproduce the above copyright notice, this list
 *       of conditions and the following disclaimer in the documentation and/or other materials
 *       provided with the distribution.
-* 
+*
 * THIS SOFTWARE IS PROVIDED BY MASSIVE INTERACTIVE ``AS IS'' AND ANY EXPRESS OR IMPLIED
 * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
 * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL MASSIVE INTERACTIVE OR
@@ -20,7 +20,7 @@
 * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-* 
+*
 * The views and conclusions contained in the software and documentation are those of the
 * authors and should not be interpreted as representing official policies, either expressed
 * or implied, of Massive Interactive.
@@ -49,12 +49,12 @@ class PrintClient implements AdvancedCoverageReportClient
 	public var includePackageBreakdown(default, default):Bool;
 	public var includeOverallPercentage(default, default):Bool;
 	public var includeSummary(default, default):Bool;
-	
+
 	public var maxBlockExecutionListSize(default, default):Int;
-		
+
 	/**
 	 * Newline delimiter. Defaults to '\n' for all platforms except 'js' where it defaults to '<br/>'.
-	 * 
+	 *
 	 * <p>
 	 * Should be set before the client is passed to a test runner.
 	 * </p>
@@ -82,10 +82,10 @@ class PrintClient implements AdvancedCoverageReportClient
 	var classCompletedCount:Int;
 	var classPartialCount:Int;
 
-	@:extern static inline var DEFAULT_TAB_WIDTH:Int = 11;
-	@:extern static inline var SHORT_FIRST_TAB_WIDTH:Int = 4;
-	@:extern static inline var LONG_FIRST_TAB_WIDTH:Int = 20;
-			
+	extern static inline var DEFAULT_TAB_WIDTH:Int = 11;
+	extern static inline var SHORT_FIRST_TAB_WIDTH:Int = 4;
+	extern static inline var LONG_FIRST_TAB_WIDTH:Int = 20;
+
 	public function new()
 	{
 		includeHeader = true;
@@ -95,13 +95,13 @@ class PrintClient implements AdvancedCoverageReportClient
 		includePackageBreakdown = true;
 		includeSummary = true;
 		includeOverallPercentage = true;
-		
+
 		maxBlockExecutionListSize = 25;
 		newline = "\n";
 		tab = " ";
 		divider = newline + "----------------------------------------------------------------";
 	}
-	
+
 	var coverage:Coverage;
 
 	public function report(coverage:Coverage):Void
@@ -114,9 +114,9 @@ class PrintClient implements AdvancedCoverageReportClient
 		packageBreakdown = "";
 		summary = "";
 		overallPercentage = "";
-	
+
 		this.coverage = coverage;
-				
+
 		printReport();
 
 		#if (php||eval)
@@ -135,7 +135,7 @@ class PrintClient implements AdvancedCoverageReportClient
 	}
 
 	function printReport()
-	{	
+	{
 		header = serializeHeader();
 		executionFrequency = serializeExecutionFrequency();
 		missingBlocks = serializeMissingBlocks();
@@ -150,13 +150,13 @@ class PrintClient implements AdvancedCoverageReportClient
 	function serializeFinalOutput():String
 	{
 		var output = "";
-	
+
 		if(includeHeader)
 		{
 			output += divider;
 			output += newline;
 			output += header;
-			output += divider;	
+			output += divider;
 		}
 
 		if(includeExecutionFrequency)
@@ -170,7 +170,7 @@ class PrintClient implements AdvancedCoverageReportClient
 			output += newline;
 			output += missingBlocks;
 		}
-	
+
 		if(includeClassBreakdown)
 		{
 			output += newline;
@@ -181,8 +181,8 @@ class PrintClient implements AdvancedCoverageReportClient
 		{
 			output += newline;
 			output += packageBreakdown;
-		}	
-		
+		}
+
 		if(includeSummary)
 		{
 			output += newline;
@@ -190,7 +190,7 @@ class PrintClient implements AdvancedCoverageReportClient
 			output += newline;
 			output += summary;
 		}
-	
+
 		if(includeOverallPercentage)
 		{
 			output += newline;
@@ -219,7 +219,7 @@ class PrintClient implements AdvancedCoverageReportClient
 		var output = "";
 		var r = coverage.getResults();
 
-	
+
 		output = printLine("OVERALL COVERAGE STATS:");
 		output += printLine("");
 
@@ -244,9 +244,9 @@ class PrintClient implements AdvancedCoverageReportClient
 		}
 		else
 		{
-			a.push("" + NumberUtil.round((count/total)*100, 2) + "%");	
+			a.push("" + NumberUtil.round((count/total)*100, 2) + "%");
 		}
-		
+
 		a.push("" + count + " / " + total);
 
 		var s:Int = SHORT_FIRST_TAB_WIDTH;
@@ -276,7 +276,7 @@ class PrintClient implements AdvancedCoverageReportClient
 		}
 
 		output += printTabs(["", "Result","Files","Classes", "Package"]);
-		
+
 		for(pckg in packages)
 		{
 			var r = pckg.getResults();
@@ -290,10 +290,10 @@ class PrintClient implements AdvancedCoverageReportClient
 	function serializeClassResults():String
 	{
 		var output = "";
-	
+
 		output = printLine("COVERAGE BREAKDOWN BY CLASSES:");
 		output += newline;
-		
+
 		var classes = coverage.getClasses();
 
 		if(Lambda.count(classes) == 0)
@@ -303,7 +303,7 @@ class PrintClient implements AdvancedCoverageReportClient
 		}
 
 		output += printTabs(["", "Result","Methods","Statements","Branches","Lines","Class"]);
-		
+
 		for(cls in classes)
 		{
 			var r = cls.getResults();
@@ -319,7 +319,7 @@ class PrintClient implements AdvancedCoverageReportClient
 	function serializeMissingBlocks():String
 	{
 		var output = "";
-		
+
 		output = printLine("MISSING STATEMENT COVERAGE:");
 		output += newline;
 
@@ -374,10 +374,10 @@ class PrintClient implements AdvancedCoverageReportClient
 
 
 
-	
+
 	/**
 	* Outputs all branch and statement logs sorted by highest frequency.
-	* For branches reports also totals for true/false  
+	* For branches reports also totals for true/false
 	*/
 
 	function serializeExecutionFrequency():String
@@ -412,7 +412,7 @@ class PrintClient implements AdvancedCoverageReportClient
 			statements.sort(statementSort);
 
 			output += printTabs(["", "Count", "Statement"]);
-			
+
 			var count = 0;
 			for(statement in statements)
 			{
@@ -437,7 +437,7 @@ class PrintClient implements AdvancedCoverageReportClient
 
 		output += newline;
 		output += printLine("TOP " + maxBlockExecutionListSize + " BRANCHES BY EXECUTION FREQUENCY:");
-		
+
 		output += newline;
 
 		if(Lambda.count(branches) == 0)
@@ -452,7 +452,7 @@ class PrintClient implements AdvancedCoverageReportClient
 			}
 
 			branches.sort(branchSort);
-		
+
 			output += printTabs(["", "Count", "True", "False", "Branch"]);
 
 			var count = 0;
@@ -506,7 +506,7 @@ class PrintClient implements AdvancedCoverageReportClient
 			{
 				s += StringTools.rpad(arg, tab, columnWidth);
 			}
-			
+
 		}
 		return newline + s;
 	}


### PR DESCRIPTION
The main change I'd like to contribute is the moving of `haxelib.json` to the project root and specifying the `classPath`, since this way it can be added as a haxelib git dependency.

Some other minor changes in this PR are replacing the deprecated `@:extern` metadata and updating `CHANGES.md`.